### PR TITLE
Implement `space` option for streamify, stringify and write

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 1.0.0 (coming soon)
 
 * Breaking change: take `stream` parameter in `walk`.
+* Add `reviver` option for `parse` and `read`.
 
 ## 0.2.0
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -27,21 +27,20 @@ module.exports = parse;
  * @option debug:   Log debug messages to the console.
  **/
 function parse (stream, options) {
-    var emitter, scopes, errors, reviver, resolve, reject, key;
+    var reviver, emitter, scopes, errors, resolve, reject, key;
 
     options = options || {};
+    reviver = options.reviver;
+    if (!options.debug) {
+        debug = function () {};
+    }
 
-    check.assert.maybe.function(options.reviver);
+    check.assert.maybe.function(reviver);
 
     emitter = walk(stream, options);
 
     scopes = [];
     errors = [];
-
-    reviver = options.reviver;
-    if (!options.debug) {
-        debug = function () {};
-    }
 
     emitter.on(events.array, array);
     emitter.on(events.object, object);

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -40,16 +40,10 @@ module.exports = streamify;
 function streamify (data, options) {
     var replacer, space, stream, emitter, json, needsComma, isProperty, awaitPush;
 
-    options = options || {};
-    replacer = options.replacer;
-    space = options.space;
-    if (!options.debug) {
-        debug = function () {};
-    }
+    normaliseOptions();
 
-    /*jshint expr:true */
-    check.function(replacer) || check.assert.maybe.array(replacer);
-    check.string(space) || check.assert.maybe.number(space);
+    check.assert.function(replacer);
+    check.assert.string(space);
 
     stream = new JsonStream(read);
     emitter = eventify(data, options);
@@ -68,6 +62,30 @@ function streamify (data, options) {
     emitter.on(events.end, end);
 
     return stream;
+
+    function normaliseOptions () {
+        options = options || {};
+
+        if (check.array(options.replacer) {
+            replacer = function (key) {
+                if (options.replacer.indexOf(key) !== -1) {
+                    return value;
+                }
+            };
+        } else {
+            replacer = options.replacer;
+        }
+
+        if (check.positive(options.space)) {
+            space = Array(options.space).join(' ');
+        } else {
+            space = options.space;
+        }
+
+        if (!options.debug) {
+            debug = function () {};
+        }
+    }
 
     function debug () {
         console.log.apply(console, arguments);

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -134,13 +134,16 @@ function streamify (data, options) {
     }
 
     function afterScope () {
-        // TODO: Migrate to after?
         needsComma = false;
 
-        after(true);
+        if (space) {
+            indentation += space;
+        }
+
+        after();
     }
 
-    function after (isScope) {
+    function after () {
         debug('after: awaitPush=%s, json=`%s`', awaitPush, json);
 
         if (awaitPush || json === '') {
@@ -149,10 +152,6 @@ function streamify (data, options) {
 
         if (!stream.push(json, 'utf8')) {
             awaitPush = true;
-        }
-
-        if (space && isScope) {
-            indentation += space;
         }
 
         json = '';

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -40,10 +40,10 @@ module.exports = streamify;
 function streamify (data, options) {
     var replacer, space, stream, emitter, json, needsComma, isProperty, awaitPush;
 
-    normaliseOptions();
+    normaliseOptions(options || {});
 
     check.assert.function(replacer);
-    check.assert.string(space);
+    check.assert.unemptyString(space);
 
     stream = new JsonStream(read);
     emitter = eventify(data, options);
@@ -63,26 +63,24 @@ function streamify (data, options) {
 
     return stream;
 
-    function normaliseOptions () {
-        options = options || {};
-
-        if (check.array(options.replacer) {
+    function normaliseOptions (rawOptions) {
+        if (check.array(rawOptions.replacer) {
             replacer = function (key) {
-                if (options.replacer.indexOf(key) !== -1) {
+                if (rawOptions.replacer.indexOf(key) !== -1) {
                     return value;
                 }
             };
         } else {
-            replacer = options.replacer;
+            replacer = rawOptions.replacer;
         }
 
-        if (check.positive(options.space)) {
-            space = Array(options.space + 1).join(' ');
+        if (check.positive(rawOptions.space)) {
+            space = Array(rawOptions.space + 1).join(' ');
         } else {
-            space = options.space;
+            space = rawOptions.space;
         }
 
-        if (!options.debug) {
+        if (!rawOptions.debug) {
             debug = function () {};
         }
     }

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -2,8 +2,9 @@
 
 'use strict';
 
-var eventify, events, JsonStream;
+var check, eventify, events, JsonStream;
 
+check = require('check-types');
 eventify = require('./eventify');
 events = require('./events');
 JsonStream = require('./jsonstream');
@@ -17,7 +18,12 @@ module.exports = streamify;
  * data. Sanely handles promises, buffers, dates, maps and other
  * iterables.
  *
- * @param data:       The data to transform
+ * @param data:       The data to transform.
+ *
+ * @option replacer:  Transformation function or whitelist array of
+ *                    keys to preserve in the output.
+ *
+ * @option space:     Indentation factor.
  *
  * @option promises:  'resolve' or 'ignore', default is 'resolve'.
  *
@@ -32,20 +38,23 @@ module.exports = streamify;
  * @option debug:     Log debug messages to the console.
  **/
 function streamify (data, options) {
-    var stream, emitter, json, needsComma, isProperty, awaitPush;
+    var replacer, space, stream, emitter, json, needsComma, isProperty, awaitPush;
 
-    // TODO: options.replacer, options.space
+    options = options || {};
+    replacer = options.replacer;
+    space = options.space;
+    if (!options.debug) {
+        debug = function () {};
+    }
+
+    check.function(replacer) || check.assert.maybe.array(replacer);
+    check.string(space) || check.assert.maybe.number(space);
 
     stream = new JsonStream(read);
     emitter = eventify(data, options);
 
-    options = options || {};
     json = '';
     awaitPush = true;
-
-    if (!options.debug) {
-        debug = function () {};
-    }
 
     emitter.on(events.array, array);
     emitter.on(events.object, object);

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -47,6 +47,7 @@ function streamify (data, options) {
         debug = function () {};
     }
 
+    /*jshint expr:true */
     check.function(replacer) || check.assert.maybe.array(replacer);
     check.string(space) || check.assert.maybe.number(space);
 

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -77,7 +77,7 @@ function streamify (data, options) {
         }
 
         if (check.positive(options.space)) {
-            space = Array(options.space).join(' ');
+            space = Array(options.space + 1).join(' ');
         } else {
             space = options.space;
         }

--- a/src/streamify.js
+++ b/src/streamify.js
@@ -20,11 +20,8 @@ module.exports = streamify;
  *
  * @param data:       The data to transform.
  *
- * @option replacer:  Transformation function, invoked breadth-first,
- *                    or whitelist array of keys to preserve in the
- *                    output.
- *
- * @option space:     Indentation factor.
+ * @option space:     Indentation string, or the number of spaces
+ *                    to indent each nested level by.
  *
  * @option promises:  'resolve' or 'ignore', default is 'resolve'.
  *
@@ -39,12 +36,11 @@ module.exports = streamify;
  * @option debug:     Log debug messages to the console.
  **/
 function streamify (data, options) {
-    var replacer, space, stream, emitter, json, indentation,
+    var space, stream, emitter, json, indentation,
         awaitPush, isProperty, needsComma;
 
     normaliseOptions(options || {});
 
-    check.assert.maybe.function(replacer);
     check.assert.maybe.unemptyString(space);
 
     stream = new JsonStream(read);
@@ -67,16 +63,6 @@ function streamify (data, options) {
     return stream;
 
     function normaliseOptions (rawOptions) {
-        if (check.array(rawOptions.replacer)) {
-            replacer = function (key) {
-                if (rawOptions.replacer.indexOf(key) !== -1) {
-                    return value;
-                }
-            };
-        } else {
-            replacer = rawOptions.replacer;
-        }
-
         if (check.positive(rawOptions.space)) {
             space = (new Array(rawOptions.space + 1)).join(' ');
         } else {

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -18,10 +18,6 @@ module.exports = stringify;
  *
  * @param data:       The data to transform
  *
- * @option replacer:  Transformation function, invoked breadth-first,
- *                    or whitelist array of keys to preserve in the
- *                    output.
- *
  * @option space:     Indentation string, or the number of spaces
  *                    to indent each nested level by.
  *
@@ -38,11 +34,7 @@ module.exports = stringify;
  * @option debug:     Log debug messages to the console.
  **/
 function stringify (data, options) {
-    var replacer, stream, json, resolve;
-
-    normaliseOptions(options || {});
-
-    check.assert.maybe.function(replacer);
+    var stream, json, resolve;
 
     stream = streamify(data, options);
     json = '';
@@ -53,18 +45,6 @@ function stringify (data, options) {
     return new Promise(function (res) {
         resolve = res;
     });
-
-    function normaliseOptions (rawOptions) {
-        if (check.array(rawOptions.replacer)) {
-            replacer = function (key, value) {
-                if (rawOptions.replacer.indexOf(key) !== -1) {
-                    return value;
-                }
-            };
-        } else {
-            replacer = rawOptions.replacer;
-        }
-    }
 
     function read (chunk) {
         json += chunk;

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -2,10 +2,7 @@
 
 'use strict';
 
-var check, streamify;
-
-check = require('check-types');
-streamify = require('./streamify');
+var streamify = require('./streamify');
 
 module.exports = stringify;
 

--- a/src/walk.js
+++ b/src/walk.js
@@ -46,8 +46,6 @@ function initialise (stream, options) {
 
     check.assert.instance(stream, require('stream').Readable);
 
-    // TODO: options.reviver
-
     options = options || {};
     json = '';
     position = {

--- a/src/write.js
+++ b/src/write.js
@@ -19,6 +19,9 @@ module.exports = write;
  *
  * @param data:       The data to transform.
  *
+ * @option space:     Indentation string, or the number of spaces
+ *                    to indent each nested level by.
+ *
  * @option promises:  'resolve' or 'ignore', default is 'resolve'.
  *
  * @option buffers:   'toString' or 'ignore', default is 'toString'.

--- a/test/streamify.js
+++ b/test/streamify.js
@@ -494,6 +494,219 @@ suite('streamify:', function () {
                 });
             });
         });
+
+        suite('streamify with space option:', function () {
+            var data, options, result;
+
+            setup(function () {
+                data = {};
+                options = { space: 2 };
+                result = streamify(data, options);
+            });
+
+            teardown(function () {
+                data = options = result = undefined;
+            });
+
+            test('JsonStream was called once', function () {
+                assert.strictEqual(log.counts.JsonStream, 1);
+            });
+
+            test('eventify was called once', function () {
+                assert.strictEqual(log.counts.eventify, 1);
+            });
+
+            test('EventEmitter.on was called nine times', function () {
+                assert.strictEqual(log.counts.on, 9);
+            });
+
+            test('stream.push was not called', function () {
+                assert.strictEqual(log.counts.push, 0);
+            });
+
+            suite('read stream, object event:', function () {
+                setup(function () {
+                    log.args.JsonStream[0][0]();
+                    log.args.on[1][1]();
+                });
+
+                test('stream.push was called once', function () {
+                    assert.strictEqual(log.counts.push, 1);
+                });
+
+                test('stream.push was called correctly', function () {
+                    assert.strictEqual(log.args.push[0][0], '{');
+                });
+
+                suite('property event:', function () {
+                    setup(function () {
+                        log.args.on[2][1]('foo');
+                    });
+
+                    test('stream.push was called once', function () {
+                        assert.strictEqual(log.counts.push, 2);
+                    });
+
+                    test('stream.push was called correctly', function () {
+                        assert.strictEqual(log.args.push[1][0], '\n  "foo":');
+                    });
+
+                    suite('string event:', function () {
+                        setup(function () {
+                            log.args.on[3][1]('bar');
+                        });
+
+                        test('stream.push was called once', function () {
+                            assert.strictEqual(log.counts.push, 3);
+                        });
+
+                        test('stream.push was called correctly', function () {
+                            assert.strictEqual(log.args.push[2][0], ' "bar"');
+                        });
+
+                        suite('property event:', function () {
+                            setup(function () {
+                                log.args.on[2][1]('baz');
+                            });
+
+                            test('stream.push was called once', function () {
+                                assert.strictEqual(log.counts.push, 4);
+                            });
+
+                            test('stream.push was called correctly', function () {
+                                assert.strictEqual(log.args.push[3][0], ',\n  "baz":');
+                            });
+
+                            suite('string event:', function () {
+                                setup(function () {
+                                    log.args.on[3][1]('qux');
+                                });
+
+                                test('stream.push was called once', function () {
+                                    assert.strictEqual(log.counts.push, 5);
+                                });
+
+                                test('stream.push was called correctly', function () {
+                                    assert.strictEqual(log.args.push[4][0], ' "qux"');
+                                });
+
+                                suite('property event:', function () {
+                                    setup(function () {
+                                        log.args.on[2][1]('wibble');
+                                    });
+
+                                    test('stream.push was called once', function () {
+                                        assert.strictEqual(log.counts.push, 6);
+                                    });
+
+                                    test('stream.push was called correctly', function () {
+                                        assert.strictEqual(log.args.push[5][0], ',\n  "wibble":');
+                                    });
+
+                                    suite('array event:', function () {
+                                        setup(function () {
+                                            log.args.on[0][1]();
+                                        });
+
+                                        test('stream.push was called once', function () {
+                                            assert.strictEqual(log.counts.push, 7);
+                                        });
+
+                                        test('stream.push was called correctly', function () {
+                                            assert.strictEqual(log.args.push[6][0], ' [');
+                                        });
+
+                                        suite('string event:', function () {
+                                            setup(function () {
+                                                log.args.on[3][1]('0');
+                                            });
+
+                                            test('stream.push was called once', function () {
+                                                assert.strictEqual(log.counts.push, 8);
+                                            });
+
+                                            test('stream.push was called correctly', function () {
+                                                assert.strictEqual(log.args.push[7][0], '\n    "0"');
+                                            });
+
+                                            suite('string event:', function () {
+                                                setup(function () {
+                                                    log.args.on[3][1]('1');
+                                                });
+
+                                                test('stream.push was called once', function () {
+                                                    assert.strictEqual(log.counts.push, 9);
+                                                });
+
+                                                test('stream.push was called correctly', function () {
+                                                    assert.strictEqual(log.args.push[8][0], ',\n    "1"');
+                                                });
+
+                                                suite('endArray event:', function () {
+                                                    setup(function () {
+                                                        log.args.on[6][1]();
+                                                    });
+
+                                                    test('stream.push was called once', function () {
+                                                        assert.strictEqual(log.counts.push, 10);
+                                                    });
+
+                                                    test('stream.push was called correctly', function () {
+                                                        assert.strictEqual(log.args.push[9][0], '\n  ]');
+                                                    });
+
+                                                    suite('property event:', function () {
+                                                        setup(function () {
+                                                            log.args.on[2][1]('a');
+                                                        });
+
+                                                        test('stream.push was called once', function () {
+                                                            assert.strictEqual(log.counts.push, 11);
+                                                        });
+
+                                                        test('stream.push was called correctly', function () {
+                                                            assert.strictEqual(log.args.push[10][0], ',\n  "a":');
+                                                        });
+
+                                                        suite('string event:', function () {
+                                                            setup(function () {
+                                                                log.args.on[3][1]('b');
+                                                            });
+
+                                                            test('stream.push was called once', function () {
+                                                                assert.strictEqual(log.counts.push, 12);
+                                                            });
+
+                                                            test('stream.push was called correctly', function () {
+                                                                assert.strictEqual(log.args.push[11][0], ' "b"');
+                                                            });
+
+                                                            suite('endObject event:', function () {
+                                                                setup(function () {
+                                                                    log.args.on[7][1]();
+                                                                });
+
+                                                                test('stream.push was called once', function () {
+                                                                    assert.strictEqual(log.counts.push, 13);
+                                                                });
+
+                                                                test('stream.push was called correctly', function () {
+                                                                    assert.strictEqual(log.args.push[12][0], '\n}');
+                                                                });
+                                                            });
+                                                        });
+                                                    });
+                                                });
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
     });
 });
 


### PR DESCRIPTION
`replacer` not implemented because the breadth-first requirement makes it a bad match for the current `eventify` implementation.