### PR TITLE
 add options hint to all examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ git clone git@github.com:philbooth/bfj.git
 ```js
 const bfj = require('bfj');
 
-bfj.read(path)
+bfj.read(path[, options])
   .then(data => {
     // :)
   })
@@ -146,7 +146,7 @@ with the first error.
 ```js
 const bfj = require('bfj');
 
-bfj.write(path, data)
+bfj.write(path, data[, options])
   .then(() => {
     // :)
   })
@@ -174,7 +174,7 @@ and an [options](#options-for-serialisation-functions) object.
 const bfj = require('bfj');
 
 // By passing a readable stream to bfj.parse():
-bfj.parse(fs.createReadStream(path))
+bfj.parse(fs.createReadStream(path)[, options])
   .then(data => {
     // :)
   })
@@ -235,7 +235,7 @@ request({ url }).pipe(bfj.unpipe((error, data) => {
 ```js
 const bfj = require('bfj');
 
-bfj.stringify(data)
+bfj.stringify(data[, options])
   .then(json => {
     // :)
   })
@@ -260,7 +260,7 @@ and an [options](#options-for-serialisation-functions) object.
 ```js
 const bfj = require('bfj');
 
-const stream = bfj.streamify(data);
+const stream = bfj.streamify(data[, options]);
 
 // Get data out of the stream with event handlers
 stream.on('data', chunk => { /* ... */ });
@@ -288,7 +288,7 @@ and an [options](#options-for-serialisation-functions) object.
 ```js
 const bfj = require('bfj');
 
-const emitter = bfj.walk(fs.createReadStream(path));
+const emitter = bfj.walk(fs.createReadStream(path)[, options]);
 
 emitter.on(bfj.events.array, () => { /* ... */ });
 emitter.on(bfj.events.object, () => { /* ... */ });
@@ -412,7 +412,7 @@ of an object,
 ```js
 const bfj = require('bfj');
 
-const emitter = bfj.eventify(data);
+const emitter = bfj.eventify(data[, options]);
 
 emitter.on(bfj.events.array, () => { /* ... */ });
 emitter.on(bfj.events.object, () => { /* ... */ });

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ git clone git@github.com:philbooth/bfj.git
 ```js
 const bfj = require('bfj');
 
-bfj.read(path[, options])
+bfj.read(path, options)
   .then(data => {
     // :)
   })
@@ -146,7 +146,7 @@ with the first error.
 ```js
 const bfj = require('bfj');
 
-bfj.write(path, data[, options])
+bfj.write(path, data, options)
   .then(() => {
     // :)
   })
@@ -174,7 +174,7 @@ and an [options](#options-for-serialisation-functions) object.
 const bfj = require('bfj');
 
 // By passing a readable stream to bfj.parse():
-bfj.parse(fs.createReadStream(path)[, options])
+bfj.parse(fs.createReadStream(path), options)
   .then(data => {
     // :)
   })
@@ -235,7 +235,7 @@ request({ url }).pipe(bfj.unpipe((error, data) => {
 ```js
 const bfj = require('bfj');
 
-bfj.stringify(data[, options])
+bfj.stringify(data, options)
   .then(json => {
     // :)
   })
@@ -260,7 +260,7 @@ and an [options](#options-for-serialisation-functions) object.
 ```js
 const bfj = require('bfj');
 
-const stream = bfj.streamify(data[, options]);
+const stream = bfj.streamify(data, options);
 
 // Get data out of the stream with event handlers
 stream.on('data', chunk => { /* ... */ });
@@ -288,7 +288,7 @@ and an [options](#options-for-serialisation-functions) object.
 ```js
 const bfj = require('bfj');
 
-const emitter = bfj.walk(fs.createReadStream(path)[, options]);
+const emitter = bfj.walk(fs.createReadStream(path), options);
 
 emitter.on(bfj.events.array, () => { /* ... */ });
 emitter.on(bfj.events.object, () => { /* ... */ });
@@ -412,7 +412,7 @@ of an object,
 ```js
 const bfj = require('bfj');
 
-const emitter = bfj.eventify(data[, options]);
+const emitter = bfj.eventify(data, options);
 
 emitter.on(bfj.events.array, () => { /* ... */ });
 emitter.on(bfj.events.object, () => { /* ... */ });


### PR DESCRIPTION
I was a little bit confused in the first point, you offer options but nowhere I could find how to apply them.

Of course, it is just an additional parameter, but I think this change here will help others to save a few minutes of lifetime by directly realizing how to pass options.


Ps.: Having about 45 characters maximum in one line in your readme makes it really hard to edit/read :P