### PR TITLE
Note minimum required Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/philbooth/bfj.git"
   },
+  "engines": {
+    "node": ">= 6.0.0"
+  },
   "dependencies": {
     "check-types": "7.1.5",
     "hoopy": "^0.1.1"


### PR DESCRIPTION
Per your note in the [README.md](https://github.com/philbooth/bfj/blob/afe79334a7bcc227c45220de6f461c480ddb4fdd/README.md#what-versions-of-nodejs-does-it-support):

> ## What versions of Node.js does it support?
> 
> As of [version `3.0.0`](HISTORY.md#300), only Node.js versions 6 or greater are supported because of the dependency on [Hoopy](https://github.com/philbooth/hoopy). Previous versions supported node 4 and later.